### PR TITLE
Exception handling if empty

### DIFF
--- a/latest-ami.py
+++ b/latest-ami.py
@@ -55,6 +55,8 @@ filters = [ {
     } ]
  
 response = client.describe_images(Owners=['amazon'], Filters=filters)
- 
-source_image = newest_image(response['Images'])
-print(source_image['ImageId'])
+if response['Images']:
+    source_image = newest_image(response['Images'])
+    print(source_image['ImageId'])
+else:
+    print "AMI list returned empty."


### PR DESCRIPTION
This works for me locally. I pulled and changed Owners=['amazon'] to my ownerid and it returned an empty list.

This caused the following error: 

```
[mash@localhost latest-ami]$ python latest-ami.py eu-central-1 
[]
Traceback (most recent call last):
  File "latest-ami.py", line 34, in <module>
    print(source_image['ImageId'])
TypeError: 'NoneType' object has no attribute '__getitem__'
```

So I added a if check, if the list is populated then source_image, otherwise, trow message and end cleanly.
